### PR TITLE
Configurable CSS preprocessor (less, sass, none)

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -65,6 +65,27 @@ module.exports = function (grunt) {
     return buildTasks;
   }
 
+  function getStyleTasks(cssPreprocessorConfig) {
+    var sassTasks = ["sass_globbing:sass", "sass"];
+    var lessTasks = ["sass_globbing:less", "less"];
+    var cssTasks = ["autoprefixer:patterns", "copy:css"];
+    var tasks = [];
+
+    if (cssPreprocessorConfig === "sass") {
+      tasks = tasks.concat(sassTasks);
+    } else if (cssPreprocessorConfig === "less") {
+      tasks = tasks.concat(lessTasks);
+    } else {
+      throw new Error("The cssPreprocessor property of patternpack configuration was not set correctly.  This property must be set to one of the following values: 'sass', 'less'.");
+    }
+
+    tasks = tasks.concat(cssTasks);
+
+    log.verbose("PatternPack CSS Preprocessor Tasks:");
+    log.verbose(tasks);
+    return tasks;
+  }
+
   grunt.initConfig({
     pkg: grunt.file.readJSON("package.json"),
 
@@ -189,13 +210,33 @@ module.exports = function (grunt) {
       }
     },
 
+    less: {
+      options: {
+        sourceMap: true,
+        outputSourceFiles: true,
+        compress: true
+      },
+      patterns: {
+        files: [
+          {
+            src: assets("/less/patterns.less"),
+            dest: assets("/css/patterns.css")
+          }
+        ]
+      }
+    },
+
     // Import all sass styles defined for patterns
     // Use the pattern structures to ensure that the styles are processed
     // in the specific order the user configures.
     "sass_globbing": {
-      all: {
+      sass: {
         src: allPatternStructurePaths("/**/*.scss"),
         dest: assets("/sass/patternpack-patterns.scss")
+      },
+      less: {
+        src: allPatternStructurePaths("/**/*.less"),
+        dest: assets("/less/patternpack-patterns.less")
       }
     },
 
@@ -292,7 +333,7 @@ module.exports = function (grunt) {
   // Modular tasks
   // These smaller grunt tasks organize work into logical groups
   // and are typically composed together into workflows
-  grunt.registerTask("styles-patterns", ["sass_globbing", "sass:patterns", "autoprefixer:patterns", "copy:css"]);
+  grunt.registerTask("styles-patterns", getStyleTasks(config.cssPreprocessor));
   grunt.registerTask("assemble-patterns", ["assemble:patterns"]);
   grunt.registerTask("assemble-pattern-library", ["assemble:patternlibrary", "copy:assets", "copy:themeAssets"]);
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -75,8 +75,6 @@ module.exports = function (grunt) {
       tasks = tasks.concat(sassTasks);
     } else if (cssPreprocessorConfig === "less") {
       tasks = tasks.concat(lessTasks);
-    } else {
-      throw new Error("The cssPreprocessor property of patternpack configuration was not set correctly.  This property must be set to one of the following values: 'sass', 'less'.");
     }
 
     tasks = tasks.concat(cssTasks);

--- a/gruntfileConfig.json
+++ b/gruntfileConfig.json
@@ -4,6 +4,7 @@
   "src": "./src",
   "assets": "./src/assets",
   "theme": "./node_modules/patternpack-example-theme",
+  "cssPreprocessor": "sass",
   "publish": {
     "library": true,
     "patterns": false

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt-contrib-clean": "latest",
     "grunt-contrib-connect": "latest",
     "grunt-contrib-copy": "latest",
+    "grunt-contrib-less": "latest",
     "grunt-contrib-watch": "latest",
     "grunt-git": "latest",
     "grunt-newer": "latest",

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ The path at which the pattern library will published.  This is the base path whe
 #### task
 Type: `string`  
 Default: `""`  
-Allowed Values: `"", default", "build, release, release-patch, release-minor, release-major`
+Allowed Values: `"", "default", "build, release, release-patch, release-minor, release-major`
 
 The action that PatternPack will take when run.
 
@@ -65,6 +65,16 @@ Type: `string`
 Default: `patternpack-example-theme`
 
 The name of the npm package (or the path) which contains the PatternPack theme.  Custom themes can be npm modules or simply files that exist within a pattern library.  By default PatternPack is configured to use the [patternpack-example-theme]
+
+#### cssPreprocessor
+Type: `string`  
+Default: `sass`
+Allowed Values: `"sass", "less", "none", ""`
+
+The type of css preprocessor to run.
+> `sass`: runs the sass preprocessor on `assets/sass/patterns.scss`
+> `less`: runs the less preprocessor on `assets/less/patterns.less`
+> `""` `none`: does not run any css preprocessor
 
 #### publish.library
 Type: `boolean`  

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -9,7 +9,8 @@ module.exports = function (grunt) {
   var npmPath = "./node_modules/";
   var packageName = "patternpack";
   var packagePath = npmPath + packageName;
-  var allowedTasks = ["", "default", "build", "release", "release-patch", "release-minor", "release-major"];
+  var tasksValues = ["default", "build", "release", "release-patch", "release-minor", "release-major", "", undefined];
+  var cssPreprocessorValues = ["less", "sass", "none", "", undefined];
   var gruntTaskName = "patternpack";
   var gruntTaskDescription = "Creates a pattern library from structured markdown and styles.";
   var optionDefaults = {
@@ -61,7 +62,7 @@ module.exports = function (grunt) {
 
     // If the task is allowed then use it as the default value.
     // Otherwise leave the task blank, which will result in "default" being called
-    if (_.contains(allowedTasks, context.target)) {
+    if (_.contains(tasksValues, context.target)) {
       optionDefaults.task = context.target;
     }
 
@@ -99,6 +100,15 @@ module.exports = function (grunt) {
     grunt.file.write(file, contents);
   }
 
+  function ensureOptions(options, name, allowedValues, allowFalsey) {
+    var value = options[name];
+    if (!_.contains(allowedValues, value)) {
+      log.log("Allowed values for " + name + "");
+      log.log(allowedValues);
+      throw new Error("The option " + name + " was set to an unacceptable value: " + value);
+    }
+  }
+
   function gruntPatternPackTask() {
     var done = this.async();
 
@@ -113,13 +123,9 @@ module.exports = function (grunt) {
     log.verbose("PatternPack options:");
     log.verbose(options);
 
-    // Ensure the task is set properly
-    if(!_.contains(allowedTasks, options.task || "")) {
-      log.log(options);
-      log.log("Allowed tasks:");
-      log.log(allowedTasks);
-      throw new Error("When specified options.task must be an allowed task.");
-    }
+    // Ensure option values are set to acceptable values
+    ensureOptions(options, "task", tasksValues);
+    ensureOptions(options, "cssPreprocessor", cssPreprocessorValues);
 
     // Save the options
     // Since I haven"t figured out how to pass the options from the command

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -19,11 +19,16 @@ module.exports = function (grunt) {
     // TODO: consider using a flag for the "MODE" of operation (dev|build|release)
     // task: "build",
 
-    // TODO: Implement the ability to only publish certain resources (css|library|patterns)
+    // Configures the css preprocessor (sass|less)
+    cssPreprocessor: "sass",
+
+    // Configures the ability to only publish certain resources (css|library|patterns)
     publish: {
       library: true,
       patterns: false
     },
+
+    // Configures the pattern hierarchy.
     patternStructure: [
       { name: "Atoms", path: "atoms" },
       { name: "Molecules", path: "molecules" },


### PR DESCRIPTION
To configure the use of less the `cssPreprocessor` property must be set in the pattern library grunt configuration.

``` js
patternpack: {
  options: {
    cssPreprocessor: "less"
  }
}
```
