### PR TITLE
Feature/option smart defaults

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,9 @@ The path at which the pattern library will published.  This is the base path whe
 
 #### theme
 Type: `string`  
-Default: `./node_modules/patternpack-example-theme`
+Default: `patternpack-example-theme`
 
-The path at which the patternpack theme can be located.  Custom themes can be npm modules or simply files that exist within a pattern library.  By default patternpack is configured to use the [patternpack-example-theme]
+The name of the npm package (or the path) which contains the PatternPack theme.  Custom themes can be npm modules or simply files that exist within a pattern library.  By default PatternPack is configured to use the [patternpack-example-theme]
 
 #### publish.library
 Type: `boolean`  

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,25 @@ Default: `./release`
 
 The path at which the pattern library will published.  This is the base path where the released pattern library assets can be found by consuming applications.
 
+#### task
+Type: `string`  
+Default: `""`  
+Allowed Values: `"", default", "build, release, release-patch, release-minor, release-major`
+
+The action that PatternPack will take when run.
+
+> `""` `default`: builds the pattern library and runs a local webserver.  
+> `build`: builds the pattern library.  
+> `release`: alias for `release-patch`.  
+> `release-patch`: patch increment to the package version, then performs a release.  
+> `release-minor`: minor increment to the package version, then performs a release.  
+> `release-major`: major increment to the package version, then performs a release.  
+
+A release performs the following actions
+* Increments the package version
+* Copies the current build to the release location
+* Commits the changes with the version number as the message
+
 #### theme
 Type: `string`  
 Default: `patternpack-example-theme`
@@ -91,11 +110,24 @@ patternpack: {
     assets: './src/assets'
   },
   run: {},
-  build: {
-    task: 'build'
+  build: {},
+  release: {}
+}
+```
+
+#### Custom task names usage
+This example shows how task names can be customized.  Configuring the the `task` option specifies what action PatternPack will take when the custom task is called.
+
+```js
+patternpack: {
+  customDev: {
+    task: 'default' // builds the application and runs the server
   },
-  release: {
-    task: 'release'
+  customBuild: {
+    task: 'build' // builds the application
+  },
+  customRelease: {
+    task: 'release' // releases the current build
   }
 }
 ```

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -9,6 +9,7 @@ module.exports = function (grunt) {
   var npmPath = "./node_modules/";
   var packageName = "patternpack";
   var packagePath = npmPath + packageName;
+  var allowedTasks = ["", "default", "build", "release", "release-patch", "release-minor", "release-major"];
   var gruntTaskName = "patternpack";
   var gruntTaskDescription = "Creates a pattern library from structured markdown and styles.";
   var optionDefaults = {
@@ -53,9 +54,9 @@ module.exports = function (grunt) {
     var path = require("path");
     var optionOverrides = context.options();
 
-    // If the task is named build or release then use it as the default value.
+    // If the task is allowed then use it as the default value.
     // Otherwise leave the task blank, which will result in "default" being called
-    if (context.target === "build" || context.target === "release") {
+    if (_.contains(allowedTasks, context.target)) {
       optionDefaults.task = context.target;
     }
 
@@ -108,9 +109,11 @@ module.exports = function (grunt) {
     log.verbose(options);
 
     // Ensure the task is set properly
-    if (options.task && options.task !== "" && options.task !== "default" && options.task !== "build" && options.task !== "release") {
+    if(!_.contains(allowedTasks, options.task || "")) {
       log.log(options);
-      throw new Error('When specified options.task must be one of the following values: "", "default", "build", "release"');
+      log.log("Allowed tasks:");
+      log.log(allowedTasks);
+      throw new Error("When specified options.task must be an allowed task.");
     }
 
     // Save the options

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -33,10 +33,15 @@ module.exports = function (grunt) {
     ]
   };
 
-
-
-  function setupOptions(optionOverrides) {
+  function setupOptions(context) {
     var path = require("path");
+    var optionOverrides = context.options();
+
+    // If the task is named build or release then use it as the default value.
+    // Otherwise leave the task blank, which will result in "default" being called
+    if (context.target === "build" || context.target === "release") {
+      optionDefaults.task = context.target;
+    }
 
     // Override the defaults with any user specified options
     var options = _.defaultsDeep(_.cloneDeep(optionOverrides), optionDefaults);
@@ -73,9 +78,15 @@ module.exports = function (grunt) {
     }
 
     // Get the options
-    var options = setupOptions(this.options());
+    var options = setupOptions(this);
     log.verbose("PatternPack options:");
     log.verbose(options);
+
+    // Ensure the task is set properly
+    if (options.task && options.task !== "" && options.task !== "default" && options.task !== "build" && options.task !== "release") {
+      log.log(options);
+      throw new Error('When specified options.task must be one of the following values: "", "default", "build", "release"');
+    }
 
     // Save the options
     // Since I haven"t figured out how to pass the options from the command


### PR DESCRIPTION
Added smart defaults for the pattern library task options.  You no longer have to specify the task value if the calling task name is "build" or "release".

Added the ability for the theme to be configured by package name rather than a strict path.

Removed the use of patternPackName from the options.
