### PR TITLE
Modified server setup to support configuration overrides

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -249,19 +249,12 @@ module.exports = function (grunt) {
 
     // Web server
     connect: {
-      server: {
-        options: {
-          port: 8888,
-          base: build("/pattern-library"),
-          hostname: "*"
-        }
+      options: {
+        base: build("/pattern-library"),
+        hostname: "*"
       },
-      browser: {
-        options: {
-          open: {
-            target: "http://localhost:8888"
-          }
-        }
+      server: {
+        options: config.server
       }
     },
 

--- a/gruntfileConfig.json
+++ b/gruntfileConfig.json
@@ -12,5 +12,8 @@
     { "name": "Atoms", "path": "atoms" },
     { "name": "Molecules", "path": "molecules" },
     { "name": "Pages", "path": "pages" }
-  ]
+  ],
+  "server": {
+    "port": 8888
+  }
 }

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -33,7 +33,10 @@ module.exports = function (grunt) {
       { name: "Atoms", path: "atoms" },
       { name: "Molecules", path: "molecules" },
       { name: "Pages", path: "pages" }
-    ]
+    ],
+    server: {
+      port: 8888
+    }
   };
 
   function getPackagePathOrFallbackPath(path) {


### PR DESCRIPTION
Sets the server port to `8888` by default and removes the automatic browser window opening.  Any desired server configurations can now be overridden by specifying the `server` property in the configuration.  This option will take any connect server configuration and will override the PatternPack defaults.

See an example configuration in the patternpack-example-library [gruntfile.js](https://github.com/patternpack/patternpack-example-library/pull/2/files)

Related to [patternpack-example-library PR#2](https://github.com/patternpack/patternpack-example-library/pull/2)
