### PR TITLE
Added application integration grunt task configuration

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -12,6 +12,10 @@ module.exports = function (grunt) {
     return getPath(config.root, path);
   }
 
+  function integrate(path) {
+    return getPath(config.integrate, path)
+  }
+
   function release(path) {
     return getPath(config.release, path);
   }
@@ -167,6 +171,15 @@ module.exports = function (grunt) {
           "!pattern-library/theme-assets/**"
         ],
         dest: release()
+      },
+      integrate: {
+        expand: true,
+        cwd: build(),
+        src: [
+          "**",
+          "!pattern-library/theme-assets/**"
+        ],
+        dest: integrate()
       },
       css: {
         src: src("/css/patterns.css"),
@@ -342,6 +355,7 @@ module.exports = function (grunt) {
   grunt.registerTask("release-major", ["clean:release", "copy:release", "gitadd", "bump:major"]);
 
   // Main tasks
+  grunt.registerTask("integrate", ["build", "copy:integrate"]);
   grunt.registerTask("release", ["clean:release", "copy:release", "release-patch"]);
   grunt.registerTask("build", getBuildTasks(config.publish));
   grunt.registerTask("default", ["build", "server"]);

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ The path at which the pattern library will published.  This is the base path whe
 #### task
 Type: `string`  
 Default: `""`  
-Allowed Values: `"", "default", "build, release, release-patch, release-minor, release-major`
+Allowed Values: `"", default, build, integrate, release, release-patch, release-minor, release-major`
 
 The action that PatternPack will take when run.
 
@@ -69,7 +69,7 @@ The name of the npm package (or the path) which contains the PatternPack theme. 
 #### cssPreprocessor
 Type: `string`  
 Default: `sass`
-Allowed Values: `"sass", "less", "none", ""`
+Allowed Values: `sass, less, none, ""`
 
 The type of css preprocessor to run.
 > `sass`: runs the sass preprocessor on `assets/sass/patterns.scss`
@@ -185,6 +185,7 @@ This example shows all options with their default options.
   build: "./html",
   src: "./src",
   assets: "./src/assets",
+  integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",
   publish: {
     library: true,

--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,21 @@ src/
   pages
 ```
 
+#### User-specific settings override
+An individual developer can override any option in the `patternpack` task by creating a `.patternpackrc` file. This is a JSON file that would mirror the contents of the `patternpack.options` portion of your task. It's recommended to add the `.patternpackrc` file to your `.gitignore`
+
+For example, to override the server configuration, set up a `.patternpackrc` file:
+
+```
+{
+  "server": {
+    "port": 1234
+  }
+}
+```
+
+Note that this file should be conforming JSON, so all strings should be wrapped in double quotes.
+
 #### All available options
 This example shows all options with their default options.
 

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Indicates whether a full pattern library will be generated.
 
 #### publish.library
 Type: `boolean`  
-Defult: `false`
+Default: `false`
 
 Indicates whether standalone patterns will be generated.  
 

--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,16 @@ Specifies the hierarchy used to organize patterns.  The default configuration re
 
 _The order of the items in the Array determines the order in which they will be displayed in the pattern library._
 
+#### server
+See the options in `[grunt-connect](https://github.com/gruntjs/grunt-contrib-connect#options)`
+
+For example:
+
+```js
+  server: {
+    port: 5555
+  }
+```
 
 ### Usage Examples
 

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
   var npmPath = "./node_modules/";
   var packageName = "patternpack";
   var packagePath = npmPath + packageName;
-  var tasksValues = ["default", "build", "release", "release-patch", "release-minor", "release-major", "", undefined];
+  var tasksValues = ["default", "build", "integrate", "release", "release-patch", "release-minor", "release-major", "", undefined];
   var cssPreprocessorValues = ["less", "sass", "none", "", undefined];
   var gruntTaskName = "patternpack";
   var gruntTaskDescription = "Creates a pattern library from structured markdown and styles.";
@@ -77,6 +77,11 @@ module.exports = function (grunt) {
     options.build = path.relative(packagePath, options.build);
     options.src = path.relative(packagePath, options.src);
     options.assets = path.relative(packagePath, options.assets);
+
+    // Resolve the application integration path if the user has provided it
+    if (optionOverrides.integrate) {
+      options.integrate = path.relative(packagePath, options.integrate);
+    }
 
     // Resolve the theme path either from a path or from a package name
     if (optionOverrides.theme) {

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -76,8 +76,8 @@ module.exports = function (grunt) {
     // Override the defaults with any user specified options
     // Apply overrides from the .patternpackrc file
     // then apply the overrries from the gruntfile options
-    options = applyOverrides(optionDefaults, optionOverridesFile);
-    options = applyOverrides(options, optionOverrides);
+    options = applyOverrides(optionDefaults, optionOverrides);
+    options = applyOverrides(options, optionOverridesFile);
 
     // Add the relative path to the root of the calling pattern library
     options.root = path.relative(packagePath, "");


### PR DESCRIPTION
Add a new grunt task “patternpack:integration” that will build then copy the files to a configured location.  In addition I have added the use of a configuration file `.patternpackrc` that can be used to set any grunt option.

``` js
{
  options: {
    integrate: “../my-application/node_modules/my-pattern-library”
  },
  integrate: {},
  run: {},
  build: {},
  release: {}
}
```
