### PR TITLE
Typo fix for patterns

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Default: `true`
 
 Indicates whether a full pattern library will be generated.
 
-#### publish.library
+#### publish.patterns
 Type: `boolean`  
 Default: `false`
 


### PR DESCRIPTION
We accidentally had `publish.library` twice. Correcting this.
