### PR TITLE
Fix css copy destination

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -182,7 +182,7 @@ module.exports = function (grunt) {
         dest: integrate()
       },
       css: {
-        src: src("/css/patterns.css"),
+        src: assets("/css/patterns.css"),
         dest: build("/css/patterns.css")
       },
       assets: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -289,7 +289,7 @@ module.exports = function (grunt) {
       },
       sass: {
         files: src("/**/*.scss"),
-        tasks: ["styles-patterns"]
+        tasks: ["styles-patterns", "copy:css"]
       },
       livereload: {
         files: build("/pattern-library/**"),


### PR DESCRIPTION
Came across a bug where the `css:copy` task was looking for the files in `src/css/patterns.css` rather than `assets/css/patterns.css,` so local development was not working.
