### PR TITLE
v1.0.1

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -183,7 +183,7 @@ module.exports = function (grunt) {
       },
       css: {
         src: assets("/css/patterns.css"),
-        dest: build("/css/patterns.css")
+        dest: build("/pattern-library/assets/css/patterns.css")
       },
       assets: {
         expand: true,

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -243,11 +243,11 @@ module.exports = function (grunt) {
     "sass_globbing": {
       sass: {
         src: allPatternStructurePaths("/**/*.scss"),
-        dest: assets("/sass/patternpack-patterns.scss")
+        dest: assets("/sass/patterns.scss")
       },
       less: {
         src: allPatternStructurePaths("/**/*.less"),
-        dest: assets("/less/patternpack-patterns.less")
+        dest: assets("/less/patterns.less")
       }
     },
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -285,7 +285,7 @@ module.exports = function (grunt) {
           theme("/**/*.{md,hbs}"),
           src("/**/*.{md,hbs}")
         ],
-        tasks: ["assemble:patternlibrary"]
+        tasks: ["assemble-pattern-library"]
       },
       sass: {
         files: src("/**/*.scss"),

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -291,6 +291,10 @@ module.exports = function (grunt) {
         files: src("/**/*.scss"),
         tasks: ["styles-patterns", "copy:css"]
       },
+      less: {
+        files: src("/**/*.less"),
+        tasks: ["styles-patterns", "copy:css"]
+      },
       livereload: {
         files: build("/pattern-library/**"),
         options: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -346,13 +346,13 @@ module.exports = function (grunt) {
 
   grunt.registerTask("server", ["connect", "watch"]);
 
-  grunt.registerTask("release-patch", ["clean:release", "copy:release", "gitadd", "bump:patch"]);
-  grunt.registerTask("release-minor", ["clean:release", "copy:release", "gitadd", "bump:minor"]);
-  grunt.registerTask("release-major", ["clean:release", "copy:release", "gitadd", "bump:major"]);
+  grunt.registerTask("release-patch", ["build", "clean:release", "copy:release", "gitadd", "bump:patch"]);
+  grunt.registerTask("release-minor", ["build", "clean:release", "copy:release", "gitadd", "bump:minor"]);
+  grunt.registerTask("release-major", ["build", "clean:release", "copy:release", "gitadd", "bump:major"]);
 
   // Main tasks
   grunt.registerTask("integrate", ["build", "copy:integrate"]);
-  grunt.registerTask("release", ["clean:release", "build", "copy:release", "release-patch"]);
+  grunt.registerTask("release", ["build", "clean:release", "copy:release", "release-patch"]);
   grunt.registerTask("build", getBuildTasks(config.publish));
   grunt.registerTask("default", ["build", "server"]);
 };

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -167,8 +167,7 @@ module.exports = function (grunt) {
         expand: true,
         cwd: build(),
         src: [
-          "**",
-          "!pattern-library/theme-assets/**"
+          "**"
         ],
         dest: release()
       },

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -352,7 +352,7 @@ module.exports = function (grunt) {
 
   // Main tasks
   grunt.registerTask("integrate", ["build", "copy:integrate"]);
-  grunt.registerTask("release", ["clean:release", "copy:release", "release-patch"]);
+  grunt.registerTask("release", ["clean:release", "build", "copy:release", "release-patch"]);
   grunt.registerTask("build", getBuildTasks(config.publish));
   grunt.registerTask("default", ["build", "server"]);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "patternpack",
   "description": "Generates pattern library content from simple markdown and css",
-  "version": "1.0.0",
+  "version": "1.0.1-beta",
   "license": "MIT",
   "dependencies": {
     "assemble": "latest",

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ grunt.loadNpmTasks('patternpack');
 ## PatternPack Task
 _Run this task with the `grunt patternpack` command._
 
-Task options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.  However the files and targets are not used at this time.
+Task options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide. However the files and targets are not used at this time.
 
 ### Options
 
@@ -27,19 +27,19 @@ Task options may be specified according to the grunt [Configuring tasks](http://
 Type: `string`  
 Default: `./src`
 
-The path at which the patterns can be located.  This is base path to all the pattern in the pattern library.
+The path at which the patterns can be located. This is base path to all the pattern in the pattern library.
 
 #### build
 Type: `string`  
 Default: `./html`
 
-The path at which the patterns library will be generated.  This is the base path where the working pattern library will be created, and can be reviewed during development.
+The path at which the patterns library will be generated. This is the base path where the working pattern library will be created, and can be reviewed during development.
 
 #### release
 Type: `string`  
 Default: `./release`
 
-The path at which the pattern library will published.  This is the base path where the released pattern library assets can be found by consuming applications.
+The path at which the pattern library will published. This is the base path where the released pattern library assets can be found by consuming applications.
 
 #### task
 Type: `string`  
@@ -48,23 +48,29 @@ Allowed Values: `"", default, build, integrate, release, release-patch, release-
 
 The action that PatternPack will take when run.
 
-> `""` `default`: builds the pattern library and runs a local webserver.  
-> `build`: builds the pattern library.  
-> `release`: alias for `release-patch`.  
-> `release-patch`: patch increment to the package version, then performs a release.  
-> `release-minor`: minor increment to the package version, then performs a release.  
-> `release-major`: major increment to the package version, then performs a release.  
+> `""` `default`: builds the pattern library and runs a local webserver.
+> `build`: builds the pattern library.
+> `release`: alias for `release-patch`.
+> `release-patch`: patch increment to the package version, then performs a release.
+> `release-minor`: minor increment to the package version, then performs a release.
+> `release-major`: major increment to the package version, then performs a release.
 
 A release performs the following actions
 * Increments the package version
 * Copies the current build to the release location
 * Commits the changes with the version number as the message
 
+#### assets
+Type: `string`
+Default: `./src/assets`
+
+A folder to house any additional assets to be shared across projects (e.g., fonts, icons, images, etc.).
+
 #### theme
 Type: `string`  
 Default: `patternpack-example-theme`
 
-The name of the npm package (or the path) which contains the PatternPack theme.  Custom themes can be npm modules or simply files that exist within a pattern library.  By default PatternPack is configured to use the [patternpack-example-theme]
+The name of the npm package (or the path) which contains the PatternPack theme. Custom themes can be npm modules or simply files that exist within a pattern library. By default PatternPack is configured to use the [patternpack-example-theme]
 
 #### cssPreprocessor
 Type: `string`  
@@ -86,9 +92,9 @@ Indicates whether a full pattern library will be generated.
 Type: `boolean`  
 Default: `false`
 
-Indicates whether standalone patterns will be generated.  
+Indicates whether standalone patterns will be generated.
 
-_This option can be useful if you would like to integrate patterns directly into another application.  For example when the patterns includes components or interations that are only available in the context of the application (such as AngularJS directives)._
+_This option can be useful if you would like to integrate patterns directly into another application. For example when the patterns includes components or interations that are only available in the context of the application (such as AngularJS directives)._
 
 #### patternStructure
 Type: `Array`  
@@ -101,10 +107,10 @@ Default:
 ]
 ```
 
-Specifies the hierarchy used to organize patterns.  The default configuration represents the atomic design hierarch, but this can be overriden with any preferred structure.
+Specifies the hierarchy used to organize patterns. The default configuration represents the atomic design hierarch, but this can be overriden with any preferred structure.
 
->`name`: The friendly name that is displayed in the pattern library.  
->`path`: The location at which the patterns can be found.  This path is relative to the `src` path.
+>`name`: The friendly name that is displayed in the pattern library.
+>`path`: The location at which the patterns can be found. This path is relative to the `src` path.
 
 _The order of the items in the Array determines the order in which they will be displayed in the pattern library._
 
@@ -122,7 +128,7 @@ For example:
 ### Usage Examples
 
 #### Basic usage
-This is an example of the most minimal configuration possible for PatternPack.  If the default conventions are followed, minimal grunt configuration is required.
+This is an example of the most minimal configuration possible for PatternPack. If the default conventions are followed, minimal grunt configuration is required.
 
 ```js
 patternpack: {
@@ -136,7 +142,7 @@ patternpack: {
 ```
 
 #### Custom task names
-This example shows how task names can be customized.  Configuring the the `task` option specifies what action PatternPack will take when the custom task is called.
+This example shows how task names can be customized. Configuring the the `task` option specifies what action PatternPack will take when the custom task is called.
 
 ```js
 patternpack: {
@@ -166,7 +172,7 @@ patternpack: {
 ```
 
 #### Custom pattern structure
-This example illustrates how to configure PatternPack to understand a differnt style of pattern hierarchy.  In this case `components`, `modules`, `templates` and `pages`.
+This example illustrates how to configure PatternPack to understand a differnt style of pattern hierarchy. In this case `components`, `modules`, `templates` and `pages`.
 
 ```js
 [
@@ -228,9 +234,9 @@ This example shows all options with their default options.
 ## PatternPack Workflow
 
 ### Pattern Library Development
-When developing new patterns for a pattern library, PatternPack provides the `patternpack:default` and `patternpack:build` tasks to assist with the process.  The `patternpack:default` task is primarily used for interactive development.  It hosts a simple webserver for reviewing changes, and will automatically compile CSS and markdown into patterns as changes are made.
+When developing new patterns for a pattern library, PatternPack provides the `patternpack:default` and `patternpack:build` tasks to assist with the process. The `patternpack:default` task is primarily used for interactive development. It hosts a simple webserver for reviewing changes, and will automatically compile CSS and markdown into patterns as changes are made.
 
-The `patternpack:build` task does not run the webserver or monitor for changes.  It is best used for manual updates and inspection of the pattern library.  It is also useful to call as part of a customized build process.
+The `patternpack:build` task does not run the webserver or monitor for changes. It is best used for manual updates and inspection of the pattern library. It is also useful to call as part of a customized build process.
 
 ### Pattern Library Release
 In order to release a new version of a pattern library you create with PatternPack, the following sequence of commands should be executed.
@@ -241,7 +247,7 @@ grunt patternpack:release
 git push --follow-tags
 ```
 
-`grunt patternpack:build` tells pattern pack to generate the pattern library.  In most cases this will done during the pattern development process. `grunt patternpack:release` increments the version of the pattern library, copies the pattern library to the release location, commits the code and tags the git repo with the new version number. `git push --follow-tags` pushes the code changes to the origin and the newly added tag.
+`grunt patternpack:build` tells pattern pack to generate the pattern library. In most cases this will done during the pattern development process. `grunt patternpack:release` increments the version of the pattern library, copies the pattern library to the release location, commits the code and tags the git repo with the new version number. `git push --follow-tags` pushes the code changes to the origin and the newly added tag.
 
 Once released your application should be able to reference the newly tagged version of the pattern library to utilize the new patterns.
 

--- a/readme.md
+++ b/readme.md
@@ -138,9 +138,6 @@ This is an example of the most minimal configuration possible for PatternPack. I
 
 ```js
 patternpack: {
-  options: {
-
-  },
   run: {},
   build: {},
   integrate: {},

--- a/readme.md
+++ b/readme.md
@@ -216,6 +216,7 @@ This example shows all options with their default options.
   build: "./html",
   src: "./src",
   assets: "./src/assets",
+  cssPreprocessor: "sass",
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",
   publish: {
@@ -226,7 +227,10 @@ This example shows all options with their default options.
     { name: "Atoms", path: "atoms" },
     { name: "Molecules", path: "molecules" },
     { name: "Pages", path: "pages" }
-  ]
+  ],
+  server: {
+    port: 1234
+  }
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ This is an example of the most minimal configuration possible for PatternPack. I
 ```js
 patternpack: {
   options: {
-    assets: './src/assets'
+
   },
   run: {},
   build: {},

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,11 @@ patternpack: {
   },
   run: {},
   build: {},
-  release: {}
+  integrate: {},
+  release: {},
+  "release-patch": {},
+  "release-minor": {},
+  "release-major": {}
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,12 @@ For example:
   }
 ```
 
+#### integrate
+Type: `string`
+Default: none
+
+Configures a directory where library builds will copy when running the `patternpack:integrate` command. Note that it is not recommended to configure this in your gruntfile when sharing across a team. Instead, use the `.patternpackrc` [method below](#user-specific-settings-override).
+
 ### Usage Examples
 
 #### Basic usage

--- a/readme.md
+++ b/readme.md
@@ -182,18 +182,22 @@ patternpack: {
 ```
 
 #### Custom pattern structure
-This example illustrates how to configure PatternPack to understand a differnt style of pattern hierarchy. In this case `components`, `modules`, `templates` and `pages`.
+Using the `patternStructure` option, you are able to configure the categories you will put your patterns in. In this case `components`, `modules`, `templates` and `pages`.
 
 ```js
-[
-  { "name": "Components", "path": "components" },
-  { "name": "Modules", "path": "modules" },
-  { "name": "Templates", "path": "tmpl" }
-  { "name": "Pages", "path": "pages" }
-]
+patternpack: {
+  options: {
+    patternStructure: [
+      { "name": "Components", "path": "components" },
+      { "name": "Modules", "path": "modules" },
+      { "name": "Templates", "path": "tmpl" }
+      { "name": "Pages", "path": "pages" }
+    ]
+  }
+}
 ```
 
-In this configuration PatterPack would look for patterns in:
+In this configuration PatternPack would look for patterns in:
 ```
 src/
   components
@@ -201,6 +205,8 @@ src/
   tmpl
   pages
 ```
+
+Where src/ is configured in [`options.src`](#src).
 
 #### User-specific settings override
 An individual developer can override any option in the `patternpack` task by creating a `.patternpackrc` file. This is a JSON file that would mirror the contents of the `patternpack.options` portion of your task. It's recommended to add the `.patternpackrc` file to your `.gitignore`

--- a/readme.md
+++ b/readme.md
@@ -270,12 +270,3 @@ git push --follow-tags
 `grunt patternpack:build` tells pattern pack to generate the pattern library. In most cases this will done during the pattern development process. `grunt patternpack:release` increments the version of the pattern library, copies the pattern library to the release location, commits the code and tags the git repo with the new version number. `git push --follow-tags` pushes the code changes to the origin and the newly added tag.
 
 Once released your application should be able to reference the newly tagged version of the pattern library to utilize the new patterns.
-
-
-## Release History
-* 2015-07-08    v0.0.1-alpha.3    Added smarter default configurations.
-* 2015-07-06    v0.0.1-alpha.2    Resolved issues with grunt loading the patternpack task.
-* 2015-07-04    v0.0.1-alpha.1    Initial release.
-
-[patternpack-example-library]:(https://github.com/patternpack/patternpack-example-library)
-[patternpack-example-theme]:(https://github.com/patternpack/patternpack-example-theme)


### PR DESCRIPTION
This is the PR to track work toward v1.0.1
## Enhancements
- [x] The build task now runs automatically on a release task
## Bugfixes
- [x] Fix build directory for grunt watch task (#11)
- [x] Fix globbing file name (#12)
- [x] Grunt Watch doesn't watch LESS files (#14)
- [x] `watch:assemble` files don't copy to the build directory
- [x] Theme assets are distributed automatically (#15)
## Documentation Updates
- [x] Add documentation for the `assets` option
- [x] Remove `assets` as a required option in the basic usage section
- [x] Added missing options to the "All Options" section
- [x] Add documentation for the `integration` option
- [x] Update [basic usage example](https://github.com/patternpack/patternpack#basic-usage) with all the tasks that are needed (e.g., `integrate`, `release-patch`, etc.)
- [x] Clarify the [custom pattern structure](https://github.com/patternpack/patternpack#custom-pattern-structure) example that all files will live inside the specified `options.src` location
