### PR TITLE
Configure the CSS File Name

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -181,8 +181,8 @@ module.exports = function (grunt) {
         dest: integrate()
       },
       css: {
-        src: assets("/css/patterns.css"),
-        dest: build("/pattern-library/assets/css/patterns.css")
+        src: assets("/css/*.css"),
+        dest: build("/pattern-library/assets/css/")
       },
       assets: {
         expand: true,
@@ -213,8 +213,8 @@ module.exports = function (grunt) {
       patterns: {
         files: [
           {
-            src: assets("/sass/patterns.scss"),
-            dest: assets("/css/patterns.css")
+            src: assets("/sass/" + config.css.fileName + ".scss"),
+            dest: assets("/css/" + config.css.fileName + ".css")
           }
         ]
       }
@@ -229,8 +229,8 @@ module.exports = function (grunt) {
       patterns: {
         files: [
           {
-            src: assets("/less/patterns.less"),
-            dest: assets("/css/patterns.css")
+            src: assets("/less/" + config.css.fileName + ".less"),
+            dest: assets("/css/" + config.css.fileName + ".css")
           }
         ]
       }
@@ -242,11 +242,11 @@ module.exports = function (grunt) {
     "sass_globbing": {
       sass: {
         src: allPatternStructurePaths("/**/*.scss"),
-        dest: assets("/sass/patterns.scss")
+        dest: assets("/sass/_patternpack-patterns.scss")
       },
       less: {
         src: allPatternStructurePaths("/**/*.less"),
-        dest: assets("/less/patterns.less")
+        dest: assets("/less/_patternpack-patterns.less")
       }
     },
 
@@ -340,7 +340,7 @@ module.exports = function (grunt) {
   // Modular tasks
   // These smaller grunt tasks organize work into logical groups
   // and are typically composed together into workflows
-  grunt.registerTask("styles-patterns", getStyleTasks(config.cssPreprocessor));
+  grunt.registerTask("styles-patterns", getStyleTasks(config.css.preProcessor));
   grunt.registerTask("assemble-patterns", ["assemble:patterns"]);
   grunt.registerTask("assemble-pattern-library", ["assemble:patternlibrary", "copy:assets", "copy:themeAssets"]);
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -340,7 +340,7 @@ module.exports = function (grunt) {
   // Modular tasks
   // These smaller grunt tasks organize work into logical groups
   // and are typically composed together into workflows
-  grunt.registerTask("styles-patterns", getStyleTasks(config.css.preProcessor));
+  grunt.registerTask("styles-patterns", getStyleTasks(config.css.preprocessor));
   grunt.registerTask("assemble-patterns", ["assemble:patterns"]);
   grunt.registerTask("assemble-pattern-library", ["assemble:patternlibrary", "copy:assets", "copy:themeAssets"]);
 

--- a/readme.md
+++ b/readme.md
@@ -72,15 +72,23 @@ Default: `patternpack-example-theme`
 
 The name of the npm package (or the path) which contains the PatternPack theme. Custom themes can be npm modules or simply files that exist within a pattern library. By default PatternPack is configured to use the [patternpack-example-theme]
 
-#### cssPreprocessor
+#### css.preProcessor
 Type: `string`  
 Default: `sass`
 Allowed Values: `sass, less, none, ""`
 
 The type of css preprocessor to run.
-> `sass`: runs the sass preprocessor on `assets/sass/patterns.scss`
-> `less`: runs the less preprocessor on `assets/less/patterns.less`
+> `sass`: runs the sass preprocessor on `assets/sass/options.css.fileName.scss`
+> `less`: runs the less preprocessor on `assets/less/options.css.fileName.less`
 > `""` `none`: does not run any css preprocessor
+
+#### css.fileName
+Type: `string`
+Default: `patterns`
+
+The final CSS file you will create that will `import` all your patterns and any other CSS you write. You will manually create this file which will be automatically watched during development and have your configured CSS preprocessor and autoprefixer run on it. Do not add an extension to this file name.
+
+It must live in your configured `assets` directory under a `sass` or `less` subdirectory (e.g., `src/assets/sass/patterns.scss`).
 
 #### publish.library
 Type: `boolean`  
@@ -229,6 +237,10 @@ This example shows all options with their default options.
   build: "./html",
   src: "./src",
   assets: "./src/assets",
+  css: {
+    preProcessor: "sass",
+    fileName: "project"
+  }
   cssPreprocessor: "sass",
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Default: `patternpack-example-theme`
 
 The name of the npm package (or the path) which contains the PatternPack theme. Custom themes can be npm modules or simply files that exist within a pattern library. By default PatternPack is configured to use the [patternpack-example-theme]
 
-#### css.preProcessor
+#### css.preprocessor
 Type: `string`  
 Default: `sass`
 Allowed Values: `sass, less, none, ""`
@@ -238,7 +238,7 @@ This example shows all options with their default options.
   src: "./src",
   assets: "./src/assets",
   css: {
-    preProcessor: "sass",
+    preprocessor: "sass",
     fileName: "project"
   }
   cssPreprocessor: "sass",

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -146,7 +146,7 @@ module.exports = function (grunt) {
 
     // Ensure option values are set to acceptable values
     ensureOptions(options, "task", tasksValues);
-    ensureOptions(options.css, "cssPreprocessor", cssPreprocessorValues);
+    ensureOptions(options.css, "preProcessor", cssPreprocessorValues);
 
     // Save the options
     // Since I haven"t figured out how to pass the options from the command

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -146,7 +146,7 @@ module.exports = function (grunt) {
 
     // Ensure option values are set to acceptable values
     ensureOptions(options, "task", tasksValues);
-    ensureOptions(options, "cssPreprocessor", cssPreprocessorValues);
+    ensureOptions(options.css, "cssPreprocessor", cssPreprocessorValues);
 
     // Save the options
     // Since I haven"t figured out how to pass the options from the command

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -28,7 +28,7 @@ module.exports = function (grunt) {
 
     // Configure our CSS
     css: {
-      preProcessor: "sass",     // which preprocessor we should use (sass|less|none)
+      preprocessor: "sass",     // which preprocessor we should use (sass|less|none)
       fileName: "patterns"      // the name for our final CSS file that will import everything
     },
 
@@ -146,7 +146,7 @@ module.exports = function (grunt) {
 
     // Ensure option values are set to acceptable values
     ensureOptions(options, "task", tasksValues);
-    ensureOptions(options.css, "preProcessor", cssPreprocessorValues);
+    ensureOptions(options.css, "preprocessor", cssPreprocessorValues);
 
     // Save the options
     // Since I haven"t figured out how to pass the options from the command

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -26,8 +26,11 @@ module.exports = function (grunt) {
     // TODO: consider using a flag for the "MODE" of operation (dev|build|release)
     // task: "build",
 
-    // Configures the css preprocessor (sass|less)
-    cssPreprocessor: "sass",
+    // Configure our CSS
+    css: {
+      preProcessor: "sass",     // which preprocessor we should use (sass|less|none)
+      fileName: "patterns"      // the name for our final CSS file that will import everything
+    },
 
     // Configures the ability to only publish certain resources (css|library|patterns)
     publish: {


### PR DESCRIPTION
This PR addresses several issues with CSS file names:
- Reverts to the previous behavior that the output file of `sass_globbing` is named differently than what the `sass` and `less` tasks watch.
- Allows the user to configure the name of the sass/less file that they will create and will be watched throughout the process
