### PR TITLE
Migrate to PostCSS & set it as user configurable

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -72,7 +72,7 @@ module.exports = function (grunt) {
   function getStyleTasks(cssPreprocessorConfig) {
     var sassTasks = ["sass_globbing:sass", "sass"];
     var lessTasks = ["sass_globbing:less", "less"];
-    var cssTasks = ["autoprefixer:patterns", "copy:css"];
+    var cssTasks = ["postcss", "copy:css"];
     var tasks = [];
 
     if (cssPreprocessorConfig === "sass") {
@@ -250,30 +250,19 @@ module.exports = function (grunt) {
       }
     },
 
-    autoprefixer: {
+    // Run PostCSS Autoprefixer on any CSS in the assets directory
+    // Using the configured Autoprefixer options (defaults to last 2 versions)
+    postcss: {
       options: {
-        browsers: ["last 2 versions", "ie >= 9"],
-        map: {
-          inline: false
-        }
-      },
-      patternlibrary: {
-        files: [{
-          expand: true,
-          flatten: true,
-          src: build("/pattern-library/assets/css/*.css"),
-          dest: build("/pattern-library/assets/css/")
-        }]
-      },
-      patterns: {
-        files: [
-          {
-            expand: true,
-            flatten: true,
-            src: build("/css/*.css"),
-            dest: build("/css/")
-          }
+        map: true,
+        processors: [
+          require('autoprefixer')(
+            config.css.autoprefixer
+          )
         ]
+      },
+      build: {
+        src: assets("/css/*.css")
       }
     },
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -4,6 +4,7 @@ module.exports = function (grunt) {
   var _ = require("lodash");
   var log = require("./gruntLogHelper.js")(grunt);
   var basePath = require("path").dirname(grunt.option("gruntfile"));
+  var autoprefixer = require("autoprefixer");
 
   var gruntFileConfig = basePath + "/gruntfileConfig.json";
   var config = grunt.file.readJSON(gruntFileConfig);
@@ -256,7 +257,7 @@ module.exports = function (grunt) {
       options: {
         map: true,
         processors: [
-          require('autoprefixer')(
+          autoprefixer(
             config.css.autoprefixer
           )
         ]

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "dependencies": {
     "assemble": "latest",
+    "autoprefixer": "latest",
     "grunt": "latest",
-    "grunt-autoprefixer": "latest",
     "grunt-bump": "latest",
     "grunt-concurrent": "latest",
     "grunt-contrib-clean": "latest",
@@ -16,6 +16,7 @@
     "grunt-contrib-watch": "latest",
     "grunt-git": "latest",
     "grunt-newer": "latest",
+    "grunt-postcss": "latest",
     "grunt-sass": "latest",
     "grunt-sass-globbing": "latest",
     "load-grunt-parent-tasks": "latest",

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,12 @@ The type of css preprocessor to run.
 > `less`: runs the less preprocessor on `assets/less/patterns.less`
 > `""` `none`: does not run any css preprocessor
 
+#### css.autoprefixer
+Type: `array`,
+Default: `browsers: ['last 2 versions']`
+
+Pass in options to PostCSS Autoprefixer. See the [available options](https://github.com/postcss/autoprefixer#options).
+
 #### publish.library
 Type: `boolean`  
 Default: `true`
@@ -229,7 +235,11 @@ This example shows all options with their default options.
   build: "./html",
   src: "./src",
   assets: "./src/assets",
-  cssPreprocessor: "sass",
+  css: {
+    autoprefixer: {
+      browsers: ['last 2 versions']
+    }
+  }
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",
   publish: {

--- a/readme.md
+++ b/readme.md
@@ -237,7 +237,7 @@ This example shows all options with their default options.
   assets: "./src/assets",
   css: {
     autoprefixer: {
-      browsers: ['last 2 versions']
+      browsers: ["last 2 versions"]
     }
   }
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -28,8 +28,6 @@ module.exports = function (grunt) {
 
     // Configure our CSS
     css: {
-      preProcessor: "sass",     // which preprocessor we should use (sass|less|none)
-      fileName: "patterns",      // the name for our final CSS file that will import everything
       autoprefixer: {
         browsers: ['last 2 versions']
       }

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -26,8 +26,14 @@ module.exports = function (grunt) {
     // TODO: consider using a flag for the "MODE" of operation (dev|build|release)
     // task: "build",
 
-    // Configures the css preprocessor (sass|less)
-    cssPreprocessor: "sass",
+    // Configure our CSS
+    css: {
+      preProcessor: "sass",     // which preprocessor we should use (sass|less|none)
+      fileName: "patterns",      // the name for our final CSS file that will import everything
+      autoprefixer: {
+        browsers: ['last 2 versions']
+      }
+    },
 
     // Configures the ability to only publish certain resources (css|library|patterns)
     publish: {

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
     // Configure our CSS
     css: {
       autoprefixer: {
-        browsers: ['last 2 versions']
+        browsers: ["last 2 versions"]
       }
     },
 


### PR DESCRIPTION
This PR handles two things:
- Migrate from autoprefixer (deprecated) to PostCSS + Autoprefixer plugin
- Allow the user to customize the Autoprefixer options
