### PR TITLE
Add assemble helper to pull in the CSS file name

### DIFF
--- a/assemble-helpers/assemble-helper-css-name.js
+++ b/assemble-helpers/assemble-helper-css-name.js
@@ -3,7 +3,8 @@ module.exports.register = function (Handlebars, options, params) {
 
   var grunt = require("grunt")
 
-  var gruntFileConfig = "../gruntfileConfig.json";
+  var basePath = require("path").dirname(grunt.option("gruntfile"));
+  var gruntFileConfig = basePath + "/gruntfileConfig.json";
   var config = grunt.file.readJSON(gruntFileConfig);
 
   Handlebars.registerHelper("cssFileName", function() {

--- a/assemble-helpers/assemble-helper-css-name.js
+++ b/assemble-helpers/assemble-helper-css-name.js
@@ -1,0 +1,12 @@
+module.exports.register = function (Handlebars, options, params) {
+  "use strict";
+
+  var grunt = require("grunt")
+
+  var gruntFileConfig = "../gruntfileConfig.json";
+  var config = grunt.file.readJSON(gruntFileConfig);
+
+  Handlebars.registerHelper("cssFileName", function() {
+    return config.css.fileName + ".css";
+  })
+};


### PR DESCRIPTION
This PR addresses the issue that opened up with the `options.css.fileName` where now the default theme would not link to the correct generated master CSS file, since it was a hard coded value.

This exposes `{{cssFileName}}` as a Handlebars helper in your theme to point at the generated master CSS file.
