### PR TITLE
Custom logo helper

### DIFF
--- a/assemble-helpers/assemble-helper-logo.js
+++ b/assemble-helpers/assemble-helper-logo.js
@@ -1,0 +1,13 @@
+module.exports.register = function (Handlebars, options, params) {
+  "use strict";
+
+  var grunt = require("grunt")
+
+  var basePath = require("path").dirname(grunt.option("gruntfile"));
+  var gruntFileConfig = basePath + "/gruntfileConfig.json";
+  var config = grunt.file.readJSON(gruntFileConfig);
+
+  Handlebars.registerHelper("logo", function() {
+    return config.logo;
+  })
+};

--- a/gruntfileConfig.json
+++ b/gruntfileConfig.json
@@ -4,6 +4,7 @@
   "src": "./src",
   "assets": "./src/assets",
   "theme": "./node_modules/patternpack-example-theme",
+  "logo": "./node_modules/patternpack-example-theme/theme-assets/images/pp-logo.svg",
   "css": {
     "preprocessor": "sass",
     "fileName": "patterns",

--- a/gruntfileConfig.json
+++ b/gruntfileConfig.json
@@ -4,7 +4,7 @@
   "src": "./src",
   "assets": "./src/assets",
   "theme": "./node_modules/patternpack-example-theme",
-  "logo": "/theme-assets/images/pp-logo.svg",
+  "logo": "/theme-assets/images/logo.svg",
   "css": {
     "preprocessor": "sass",
     "fileName": "patterns",

--- a/gruntfileConfig.json
+++ b/gruntfileConfig.json
@@ -4,7 +4,7 @@
   "src": "./src",
   "assets": "./src/assets",
   "theme": "./node_modules/patternpack-example-theme",
-  "logo": "./node_modules/patternpack-example-theme/theme-assets/images/pp-logo.svg",
+  "logo": "/theme-assets/images/pp-logo.svg",
   "css": {
     "preprocessor": "sass",
     "fileName": "patterns",

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ The name of the npm package (or the path) which contains the PatternPack theme. 
 
 #### logo
 Type: `string`
-Default: `/theme-assets/images/pp-logo.svg`
+Default: `/theme-assets/images/logo.svg`
 
 *Note: if you are using a custom `options.theme` value, this option is not necessary*
 
@@ -262,7 +262,7 @@ This example shows all options with their default options.
   }
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",
-  logo: "./theme-assets/images/pp-logo.svg",
+  logo: "./theme-assets/images/logo.svg",
   publish: {
     library: true,
     patterns: false

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ This example shows all options with their default options.
   }
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",
-  logo: "./theme-assets/images/pp-logo.svg"
+  logo: "./theme-assets/images/pp-logo.svg",
   publish: {
     library: true,
     patterns: false

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,16 @@ Default: `patternpack-example-theme`
 
 The name of the npm package (or the path) which contains the PatternPack theme. Custom themes can be npm modules or simply files that exist within a pattern library. By default PatternPack is configured to use the [patternpack-example-theme]
 
+#### logo
+Type: `string`
+Default: `/theme-assets/images/pp-logo.svg`
+
+*Note: if you are using a custom `options.theme` value, this option is not necessary*
+
+If you're using the default theme, you can pass in a custom logo to be used with your library. It should be the path to your logo file relative to the build directory (`./html/` if you didn't configure `options.build`). It's recommended to put the logo inside of the `./src/assets/images` directory, and then pass in a value of `/assets/images/yourLogo.png`.
+
+The logo will be resized via CSS to a `max-height` of 30px.
+
 #### css.preprocessor
 Type: `string`  
 Default: `sass`
@@ -252,6 +262,7 @@ This example shows all options with their default options.
   }
   integrate: "../patternpack-example-app/node_modules/patternpack-example-library",
   theme: "./node_modules/patternpack-example-theme",
+  logo: "./theme-assets/images/pp-logo.svg"
   publish: {
     library: true,
     patterns: false

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -21,6 +21,7 @@ module.exports = function (grunt) {
     src: "./src",
     assets: "./src/assets",
     theme: npmPath + "patternpack-example-theme",
+    logo: "/theme-assets/images/pp-logo.svg",
 
     // Operation to run (default|build|release)
     // TODO: consider using a flag for the "MODE" of operation (dev|build|release)

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
     src: "./src",
     assets: "./src/assets",
     theme: npmPath + "patternpack-example-theme",
-    logo: "/theme-assets/images/pp-logo.svg",
+    logo: "/theme-assets/images/logo.svg",
 
     // Operation to run (default|build|release)
     // TODO: consider using a flag for the "MODE" of operation (dev|build|release)


### PR DESCRIPTION
Allows the developer to pass in an `options.logo` value that will expose a `{{logo}}` helpers to Assemble to customize the logo in the out of the box theme.
