### PR TITLE
Fixed copy:css task configuration

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -182,8 +182,12 @@ module.exports = function (grunt) {
         dest: integrate()
       },
       css: {
-        src: assets("/css/*.css"),
-        dest: build("/pattern-library/assets/css/")
+        expand: true,
+        cwd: assets(),
+        src: [
+          "css/**"
+        ],
+        dest: build("/pattern-library/assets")
       },
       assets: {
         expand: true,


### PR DESCRIPTION
The incorrect configuration was causing the creating of an extra path
`src/assets/css`.  This fix ensure that the css files are copied to
`assets/css`.

Resolves issue #31 
