### PR TITLE
Fixed problem with duplicate builds when running release

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -352,7 +352,7 @@ module.exports = function (grunt) {
 
   // Main tasks
   grunt.registerTask("integrate", ["build", "copy:integrate"]);
-  grunt.registerTask("release", ["build", "clean:release", "copy:release", "release-patch"]);
+  grunt.registerTask("release", ["release-patch"]);
   grunt.registerTask("build", getBuildTasks(config.publish));
   grunt.registerTask("default", ["build", "server"]);
 };


### PR DESCRIPTION
When running `patternpack:release` the build process was being run
multiple times.  These changes ensure that it only is built a single
time.

Resolves issue #30 
