### PR TITLE
Create default css file and pattern directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "load-grunt-parent-tasks": "^0.1.1",
     "lodash": "^3.10.1",
     "merge-defaults": "^0.2.1",
+    "mkdirp": "^0.5.1",
     "patternpack-example-theme": "^1.0.0",
     "pretty": "^1.0.0"
   },

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -140,53 +140,35 @@ module.exports = function (grunt) {
   }
 
   function ensureFilesExist(options) {
+    // TODO: File generation should be enhanced to use templates rather than
+    //       the current implementation that generates the files inline.
     var path = require("path");
-
-    log.verbose("Validating required files exist...");
-
-    // Generate the options.src directory if it doesn't exist
-    var sourceDirectory = options.src;
-    if (!fs.existsSync(sourceDirectory)) {
-      log.verbose("Generating the source directory: " + sourceDirectory);
-      fs.mkdir(sourceDirectory);
-    }
-
-    // Generate the options.assets directory if it doesn't exist
-    var assetsDirectory = options.assets;
-    if (!fs.existsSync(assetsDirectory)) {
-      log.verbose("Generating the assets directory: " + assetsDirectory);
-      fs.mkdir(assetsDirectory);
-    }
+    var mkdirp = require("mkdirp");
 
     // Create core css file if it does not exist
-    var coreCssDirectory = assetsDirectory + "/" + options.css.preprocessor;
-    var coreCssExtension = options.css.preprocessor;
-    if (options.css.preprocessor === "sass") {    // convert file extension to scss if sass is passed in
-      coreCssExtension = "scss";
-    }
+    var coreCssExtension = options.css.preprocessor === "sass" ? "scss" : options.css.preprocessor;
     var coreCssFileName = options.css.fileName + "." + coreCssExtension;
-
+    var coreCssDirectory = options.assets + "/" + options.css.preprocessor;
     var coreCssPath = coreCssDirectory + "/" + coreCssFileName;
+
     if (!fs.existsSync(coreCssPath)) {
       log.verbose("Generating the core CSS file: " + coreCssPath);
-      fs.mkdir(coreCssDirectory);
+      mkdirp.sync(coreCssDirectory);
       fs.writeFileSync(coreCssPath, '@import "patternpack-patterns";');
     }
 
     // Create the dirctories for the pattern structure if they do not exist
     _.each(options.patternStructure, function(pattern) {
-      var patternPath = options.src + "/" + pattern.path;
-      if (!fs.existsSync(patternPath)) {
-        log.verbose("Generating the " + patternpath + " patterns directory");
-        fs.mkdir(patternPath);
+      if (!fs.existsSync(options.src + "/" + pattern.path)) {
+        log.verbose("Generating the pattern directory: " + options.src + "/" + pattern.path);
+        fs.mkdir(options.src + "/" + pattern.path);
       }
     });
 
     // Generate a placeholder index.md file
-    // TODO: Move this to a templates folder
-    var indexFile = sourceDirectory + "/index.md";
+    var indexFile = options.src + "/index.md";
     if (!fs.existsSync(indexFile)) {
-      log.verbose("Generating the core CSS file: " + coreCssPath);
+      log.verbose("Generating the index file: " + coreCssPath);
       fs.writeFileSync(indexFile, '# Welcome to PatternPack');
     }
   }

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -142,19 +142,53 @@ module.exports = function (grunt) {
   function ensureFilesExist(options) {
     var path = require("path");
 
+    log.verbose("Validating required files exist...");
+
+    // Generate the options.src directory if it doesn't exist
+    var sourceDirectory = options.src;
+    if (!fs.existsSync(sourceDirectory)) {
+      log.verbose("Generating the source directory: " + sourceDirectory);
+      fs.mkdir(sourceDirectory);
+    }
+
+    // Generate the options.assets directory if it doesn't exist
+    var assetsDirectory = options.assets;
+    if (!fs.existsSync(assetsDirectory)) {
+      log.verbose("Generating the assets directory: " + assetsDirectory);
+      fs.mkdir(assetsDirectory);
+    }
+
     // Create core css file if it does not exist
-    var coreCssPath = options.assets + "/" + options.css.preprocessor + "/" + options.css.fileName + "." + options.css.preprocessor;
+    var coreCssDirectory = assetsDirectory + "/" + options.css.preprocessor;
+    var coreCssExtension = options.css.preprocessor;
+    if (options.css.preprocessor === "sass") {    // convert file extension to scss if sass is passed in
+      coreCssExtension = "scss";
+    }
+    var coreCssFileName = options.css.fileName + "." + coreCssExtension;
+
+    var coreCssPath = coreCssDirectory + "/" + coreCssFileName;
     if (!fs.existsSync(coreCssPath)) {
-      fs.writeFileSync(coreCssPath, '@import "_patternpack-patterns"');
+      log.verbose("Generating the core CSS file: " + coreCssPath);
+      fs.mkdir(coreCssDirectory);
+      fs.writeFileSync(coreCssPath, '@import "patternpack-patterns";');
     }
 
     // Create the dirctories for the pattern structure if they do not exist
     _.each(options.patternStructure, function(pattern) {
       var patternPath = options.src + "/" + pattern.path;
       if (!fs.existsSync(patternPath)) {
+        log.verbose("Generating the " + patternpath + " patterns directory");
         fs.mkdir(patternPath);
       }
     });
+
+    // Generate a placeholder index.md file
+    // TODO: Move this to a templates folder
+    var indexFile = sourceDirectory + "/index.md";
+    if (!fs.existsSync(indexFile)) {
+      log.verbose("Generating the core CSS file: " + coreCssPath);
+      fs.writeFileSync(indexFile, '# Welcome to PatternPack');
+    }
   }
 
   function gruntPatternPackTask() {

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -71,8 +71,7 @@ module.exports = function (grunt) {
     return _.defaultsDeep(_.cloneDeep(overrideValue), value);
   }
 
-  function setupOptions(context) {
-    var path = require("path");
+  function getOptions(context) {
     var options = {};
     var optionOverrides = context.options();
     var optionOverridesFile = grunt.file.exists(optionsOverrideFileName) ? grunt.file.readJSON(optionsOverrideFileName) : {};
@@ -89,6 +88,25 @@ module.exports = function (grunt) {
     options = applyOverrides(optionDefaults, optionOverrides);
     options = applyOverrides(options, optionOverridesFile);
 
+    // Resolve the theme path either from a path or from a package name
+    if (optionOverrides.theme) {
+      optionOverrides.theme = getPackagePathOrFallbackPath(optionOverrides.theme);
+    }
+    log.verbose("Theme paths");
+    log.verbose("Default: " + optionDefaults.theme);
+    log.verbose("Override: " + optionOverrides.theme);
+
+    // If the pattern is specified by the user then get the relative path,
+    // otherwise use the path inside pattern pack to provide the default patterns.
+    options.theme = optionOverrides.theme ? path.relative(packagePath, optionOverrides.theme) : optionDefaults.theme;
+    log.verbose("Resolved: " + options.theme);
+
+    return options;
+  }
+
+  function transformOptions(options) {
+    var path = require("path");
+
     // Add the relative path to the root of the calling pattern library
     options.root = path.relative(packagePath, "");
 
@@ -102,19 +120,6 @@ module.exports = function (grunt) {
     if (options.integrate) {
       options.integrate = path.relative(packagePath, options.integrate);
     }
-
-    // Resolve the theme path either from a path or from a package name
-    if (optionOverrides.theme) {
-      optionOverrides.theme = getPackagePathOrFallbackPath(optionOverrides.theme);
-    }
-    log.verbose("Theme paths");
-    log.verbose("Default: " + optionDefaults.theme);
-    log.verbose("Override: " + optionOverrides.theme);
-
-    // If the pattern is specified by the user then get the relative path,
-    // otherwise use the path inside pattern pack to provide the default patterns.
-    options.theme = optionOverrides.theme ? path.relative(packagePath, optionOverrides.theme) : optionDefaults.theme;
-    log.verbose("Resolved: " + options.theme);
 
     return options;
   }
@@ -134,6 +139,24 @@ module.exports = function (grunt) {
     }
   }
 
+  function ensureFilesExist(options) {
+    var path = require("path");
+
+    // Create core css file if it does not exist
+    var coreCssPath = options.assets + "/" + options.css.preprocessor + "/" + options.css.fileName + "." + options.css.preprocessor;
+    if (!fs.existsSync(coreCssPath)) {
+      fs.writeFileSync(coreCssPath, '@import "_patternpack-patterns"');
+    }
+
+    // Create the dirctories for the pattern structure if they do not exist
+    _.each(options.patternStructure, function(pattern) {
+      var patternPath = options.src + "/" + pattern.path;
+      if (!fs.existsSync(patternPath)) {
+        fs.mkdir(patternPath);
+      }
+    });
+  }
+
   function gruntPatternPackTask() {
     var done = this.async();
 
@@ -144,13 +167,18 @@ module.exports = function (grunt) {
     }
 
     // Get the options
-    var options = setupOptions(this);
-    log.verbose("PatternPack options:");
-    log.verbose(options);
+    var options = getOptions(this);
 
     // Ensure option values are set to acceptable values
+    // and files/directories are present
     ensureOptions(options, "task", tasksValues);
     ensureOptions(options.css, "preprocessor", cssPreprocessorValues);
+    ensureFilesExist(options);
+
+    // Change the options to be relative to the patternpackage package
+    options = transformOptions(options);
+    log.verbose("PatternPack options:");
+    log.verbose(options);
 
     // Save the options
     // Since I haven"t figured out how to pass the options from the command

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
     if (!fs.existsSync(coreCssPath)) {
       log.verbose("Generating the core CSS file: " + coreCssPath);
       mkdirp.sync(coreCssDirectory);
-      fs.writeFileSync(coreCssPath, '@import "patternpack-patterns";');
+      fs.writeFileSync(coreCssPath, '@import "_patternpack-patterns";');    // TODO: Make this a template based on Sass/LESS - LESS requires the underscore
     }
 
     // Create the dirctories for the pattern structure if they do not exist


### PR DESCRIPTION
Modified the patternpack grunt task to automatically create files and directories.
- Creates `src/assets/{css.preprocessor}/{css.fileName}`
- Creates all the pattern directories `src/atoms`, `src/molecules`, etc
