### PR TITLE
Provide ability for themes to define custom assemble helpers

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
     assemble: {
       options: {
         patternStructure: config.patternStructure,
-        helpers: ["assemble-helpers/assemble-helper-*.js"],
+        helpers: [theme("/assemble-helpers/*.js"), "assemble-helpers/assemble-helper-*.js"],
         partials: theme("/partials/*.hbs"),
         postprocess: require("pretty")
       },


### PR DESCRIPTION
This includes themes being able to register custom Handlebar helpers.

@johngully I went ahead and pushed up this PR for you to take a look at. I like how it just provides more power & flexibility to themes, independent of how you may end up DRYing up pattern definitions.

I would love to see this in the next release that I could pull down in my project!

Definitely open to changing the name of the folder, or making that folder name customizable as well, but like we chatted about it seems to make sense that handlebar extensions would live in the theme, not the pattern library itself, and having a documented folder doesn't seem bad (since `layouts/_pattern-library.hbs` and `partials/*.hbs` are already hard coded and assumed to exist in your theme).

BTW I ensured that this change will not break any projects using a theme that does not have that folder in the file structure.
