### PR TITLE
Pass custom data into Assemble

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -37,6 +37,10 @@ module.exports = function (grunt) {
     return getPath(config.theme, path);
   }
 
+  function data(path) {
+    return getPath(config.data, path);
+  }
+
   function getPath(configPath, path) {
     path = path || "";
     return configPath + path;
@@ -123,7 +127,8 @@ module.exports = function (grunt) {
         patternStructure: config.patternStructure,
         helpers: [theme("/assemble-helpers/*.js"), "assemble-helpers/assemble-helper-*.js"],
         partials: theme("/partials/*.hbs"),
-        postprocess: require("pretty")
+        postprocess: require("pretty"),
+        data: data("/**/*.{json,yml}")
       },
       // Build the pattern library (fully functioning website)
       patternlibrary: {

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,12 @@ Default: `patternpack-example-theme`
 
 The name of the npm package (or the path) which contains the PatternPack theme. Custom themes can be npm modules or simply files that exist within a pattern library. By default PatternPack is configured to use the [patternpack-example-theme](https://github.com/patternpack/patternpack-example-library)
 
+#### data
+Type: `string`
+Default: `./data`
+
+Allows you to pass JSON or YML data files from this directory into your pages. By default, it would be exposed as `{{filename}}`. To learn more look at the [Assemble's documentation on supplying data to templates](http://assemble.io/docs/options-data.html).
+
 #### logo
 Type: `string`  
 Default: `/theme-assets/images/logo.svg`

--- a/tasks/patternpack.js
+++ b/tasks/patternpack.js
@@ -21,6 +21,7 @@ module.exports = function (grunt) {
     src: "./src",
     assets: "./src/assets",
     theme: "patternpack-example-theme",
+    data: "./data",
     logo: "/theme-assets/images/logo.svg",
 
     // Operation to run (default|build|release)
@@ -133,6 +134,7 @@ module.exports = function (grunt) {
     options.build = path.relative(packagePath, options.build);
     options.src = path.relative(packagePath, options.src);
     options.assets = path.relative(packagePath, options.assets);
+    options.data = path.relative(packagePath, options.data);
 
     // Resolve the application integration path if the user has provided it
     if (options.integrate) {


### PR DESCRIPTION
Assemble has built in support for parsing JSON or YAML data and passing it into your templates and pages through Handlebars. This PR allows someone to define a custom data folder.
