### PR TITLE
Modified code to support breaking change in node v6

### DIFF
--- a/assemble-helpers/assemble-helper-css-name.js
+++ b/assemble-helpers/assemble-helper-css-name.js
@@ -3,7 +3,8 @@ module.exports.register = function (Handlebars, options, params) {
 
   var grunt = require("grunt")
 
-  var basePath = require("path").dirname(grunt.option("gruntfile"));
+  var gruntfilePath = grunt.option("gruntfile") || ".";
+  var basePath = require("path").dirname(gruntfilePath);
   var gruntFileConfig = basePath + "/gruntfileConfig.json";
   var config = grunt.file.readJSON(gruntFileConfig);
 

--- a/assemble-helpers/assemble-helper-logo.js
+++ b/assemble-helpers/assemble-helper-logo.js
@@ -3,7 +3,8 @@ module.exports.register = function (Handlebars, options, params) {
 
   var grunt = require("grunt")
 
-  var basePath = require("path").dirname(grunt.option("gruntfile"));
+  var gruntfilePath = grunt.option("gruntfile") || ".";
+  var basePath = require("path").dirname(gruntfilePath);
   var gruntFileConfig = basePath + "/gruntfileConfig.json";
   var config = grunt.file.readJSON(gruntFileConfig);
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -3,7 +3,8 @@ module.exports = function (grunt) {
 
   var _ = require("lodash");
   var log = require("./gruntLogHelper.js")(grunt);
-  var basePath = require("path").dirname(grunt.option("gruntfile"));
+  var gruntfilePath = grunt.option("gruntfile") || ".";
+  var basePath = require("path").dirname(gruntfilePath);
   var autoprefixer = require("autoprefixer");
 
   var gruntFileConfig = basePath + "/gruntfileConfig.json";


### PR DESCRIPTION
path.dirname(undefined) throws an exception in newer versions of node.
Modified the code to provide a fallback value in the case where no
gruntfile option is specified.

fixes #81, #80 
